### PR TITLE
Add a mechanism for categorizing errors

### DIFF
--- a/clusters/clusters.go
+++ b/clusters/clusters.go
@@ -593,7 +593,7 @@ func FindClusters(namespace string, client *kclient.Client) ([]SparkCluster, err
 			citem.Href = "/clusters/" + clustername
 
 			// Note, we do not report an error here since we are
-			// reporting on multiple clusterconfigs. Instead cnt will be -1.
+			// reporting on multiple clusters. Instead cnt will be -1.
 			cnt, _, _ := countWorkers(pc, clustername)
 
 			// TODO we only want to count running pods (not terminating)

--- a/clusters/errors.go
+++ b/clusters/errors.go
@@ -1,0 +1,29 @@
+package clusters
+
+const NoCodeAvailable = 0
+const ClusterConfigCode = 100
+const ClientOperationCode = 101
+const ClusterIncompleteCode = 102
+const NoSuchClusterCode = 103
+const ComponentExistsCode = 104
+
+type ClusterError struct {
+	Msg string
+	Code int
+}
+
+func (e ClusterError) Error() string {
+	return e.Msg
+}
+
+func NewClusterError(msg string, code int) ClusterError {
+	return ClusterError{Msg: msg, Code: code}
+}
+
+func ErrorCode(err error) int {
+	ce, ok := err.(ClusterError)
+	if ok {
+		return ce.Code
+	}
+	return NoCodeAvailable
+}


### PR DESCRIPTION
This change adds a custom error struct which contains an error
code to categorize the error. This allows clients to determine
whether or not an error is a system error or caused by user
mistake (such as operating on a cluster which does not exist).
This is particularly helpful for REST clients which need to
report proper HTTP status codes.