### PR TITLE
Name of clusterconfig should be returned.

### DIFF
--- a/clusters/clusterconfigs.go
+++ b/clusters/clusterconfigs.go
@@ -40,6 +40,9 @@ func GetDefaultConfig() ClusterConfig {
 }
 
 func assignConfig(res *ClusterConfig, src ClusterConfig) {
+        if src.Name != "" {
+		res.Name = src.Name
+        }
 	if src.MasterCount != 0 {
 		res.MasterCount = src.MasterCount
 	}


### PR DESCRIPTION
When a named cluster config is used to create a cluster, the
name of that cluster config is not being returned in the response.