### PR TITLE
Allow spark image to be specified in clusterconfigs

### DIFF
--- a/clusters/clusterconfigs.go
+++ b/clusters/clusterconfigs.go
@@ -14,6 +14,7 @@ type ClusterConfig struct {
 	Name string
 	SparkMasterConfig string
 	SparkWorkerConfig string
+	SparkImage string
 }
 
 
@@ -22,7 +23,8 @@ var defaultConfig ClusterConfig = ClusterConfig{
 	                                                        WorkerCount: 1,
 								Name: "default",
 								SparkMasterConfig: "",
-								SparkWorkerConfig: ""}
+								SparkWorkerConfig: "",
+								SparkImage: ""}
 
 const Defaultname = "default"
 const failOnMissing = true
@@ -55,6 +57,9 @@ func assignConfig(res *ClusterConfig, src ClusterConfig) {
 	}
 	if src.SparkWorkerConfig != "" {
 		res.SparkWorkerConfig = src.SparkWorkerConfig
+	}
+	if src.SparkImage != "" {
+		res.SparkImage = src.SparkImage
 	}
 }
 
@@ -93,6 +98,8 @@ func process(config *ClusterConfig, name, value, configmapname string) error {
                 config.SparkMasterConfig = strings.Trim(value, "\n")
 	case "sparkworkerconfig":
                 config.SparkWorkerConfig = strings.Trim(value, "\n")
+	case "sparkimage":
+		config.SparkImage = strings.Trim(value, "\n")
 	}
 	return err
 }

--- a/clusters/clusters.go
+++ b/clusters/clusters.go
@@ -30,6 +30,7 @@ const mastermsg = "unable to find spark masters"
 const updateReplMsg = "unable to update replication controller for spark workers"
 const noSuchClusterMsg = "no such cluster '%s'"
 const podListMsg = "unable to retrive pod list"
+const sparkImageMsg = "no spark image specified"
 
 const typeLabel = "oshinko-type"
 const clusterLabel = "oshinko-cluster"
@@ -276,6 +277,12 @@ func CreateCluster(clustername, namespace, sparkimage string, config *ClusterCon
 	if err != nil {
 		return result, generalErr(err, clusterConfigMsg, ErrorCode(err))
 	}
+	if finalconfig.SparkImage != "" {
+		sparkimage = finalconfig.SparkImage
+	} else if sparkimage == "" {
+		return result, generalErr(nil, sparkImageMsg, ClusterConfigCode)
+	}
+
 	workercount := int(finalconfig.WorkerCount)
 
 	// Check if finalconfig contains the names of ConfigMaps to use for spark


### PR DESCRIPTION
The create routine already allows the image value to be passed
in as an argument. Allow the image to be set in a cluster config
as well, which will take precedence. This