### PR TITLE
Update to 1.4.1 release of origin

### DIFF
--- a/clusters/clusterconfigs.go
+++ b/clusters/clusterconfigs.go
@@ -2,29 +2,27 @@ package clusters
 
 import (
 	"fmt"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 	"strconv"
 	"strings"
-	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 )
 
 type ClusterConfig struct {
-
-	MasterCount int
-	WorkerCount int
-	Name string
+	MasterCount       int
+	WorkerCount       int
+	Name              string
 	SparkMasterConfig string
 	SparkWorkerConfig string
-	SparkImage string
+	SparkImage        string
 }
 
-
 var defaultConfig ClusterConfig = ClusterConfig{
-								MasterCount: 1,
-	                                                        WorkerCount: 1,
-								Name: "default",
-								SparkMasterConfig: "",
-								SparkWorkerConfig: "",
-								SparkImage: ""}
+	MasterCount:       1,
+	WorkerCount:       1,
+	Name:              "default",
+	SparkMasterConfig: "",
+	SparkWorkerConfig: "",
+	SparkImage:        ""}
 
 const Defaultname = "default"
 const failOnMissing = true
@@ -35,16 +33,15 @@ const WorkerCountMustBeAtLeastOne = "cluster configuration may not have a worker
 const ErrorWhileProcessing = "'%s', %s"
 const NamedConfigDoesNotExist = "named config '%s' does not exist"
 
-
 // This function is meant to support testability
 func GetDefaultConfig() ClusterConfig {
 	return defaultConfig
 }
 
 func assignConfig(res *ClusterConfig, src ClusterConfig) {
-        if src.Name != "" {
+	if src.Name != "" {
 		res.Name = src.Name
-        }
+	}
 	if src.MasterCount != 0 {
 		res.MasterCount = src.MasterCount
 	}
@@ -73,7 +70,6 @@ func checkConfiguration(config ClusterConfig) error {
 	return err
 }
 
-
 func getInt(value, configmapname string) (int, error) {
 	i, err := strconv.Atoi(strings.Trim(value, "\n"))
 	if err != nil {
@@ -91,13 +87,13 @@ func process(config *ClusterConfig, name, value, configmapname string) error {
 	// the first element in the name
 	switch name {
 	case "mastercount":
-		config.MasterCount, err = getInt(value, configmapname + ".mastercount")
+		config.MasterCount, err = getInt(value, configmapname+".mastercount")
 	case "workercount":
-		config.WorkerCount, err = getInt(value, configmapname + ".workercount")
+		config.WorkerCount, err = getInt(value, configmapname+".workercount")
 	case "sparkmasterconfig":
-                config.SparkMasterConfig = strings.Trim(value, "\n")
+		config.SparkMasterConfig = strings.Trim(value, "\n")
 	case "sparkworkerconfig":
-                config.SparkWorkerConfig = strings.Trim(value, "\n")
+		config.SparkWorkerConfig = strings.Trim(value, "\n")
 	case "sparkimage":
 		config.SparkImage = strings.Trim(value, "\n")
 	}
@@ -119,7 +115,7 @@ func readConfig(name string, res *ClusterConfig, failOnMissing bool, cm kclient.
 		}
 	}
 	if err == nil && cmap != nil {
-		for n, v := range (cmap.Data) {
+		for n, v := range cmap.Data {
 			err = process(res, n, v, name)
 			if err != nil {
 				break
@@ -140,9 +136,9 @@ func loadConfig(name string, cm kclient.ConfigMapsInterface) (res ClusterConfig,
 }
 
 func GetClusterConfig(config *ClusterConfig, cm kclient.ConfigMapsInterface) (res ClusterConfig, err error) {
-        var name string = ""
+	var name string = ""
 	if config != nil {
-	   name = config.Name
+		name = config.Name
 	}
 	res, err = loadConfig(name, cm)
 	if err == nil && config != nil {

--- a/clusters/containers/containers.go
+++ b/clusters/containers/containers.go
@@ -84,7 +84,7 @@ type OContainerPort struct {
 func ContainerPort(name string, port int) *OContainerPort {
 	cp := OContainerPort{}
 	cp.Name = name
-	cp.ContainerPort.ContainerPort = port
+	cp.ContainerPort.ContainerPort = int32(port)
 	cp.ContainerPort.Protocol = kapi.ProtocolTCP
 	return &cp
 }
@@ -100,7 +100,7 @@ func (cp *OContainerPort) SetName(name string) *OContainerPort {
 }
 
 func (cp *OContainerPort) HostPort(port int) *OContainerPort {
-	cp.ContainerPort.HostPort = port
+	cp.ContainerPort.HostPort = int32(port)
 	return cp
 }
 

--- a/clusters/deploymentconfigs/deploymentconfigs.go
+++ b/clusters/deploymentconfigs/deploymentconfigs.go
@@ -24,7 +24,7 @@ func DeploymentConfig(name, namespace string) *ODeploymentConfig {
 }
 
 func (dc *ODeploymentConfig) Replicas(r int) *ODeploymentConfig {
-	dc.Spec.Replicas = r
+	dc.Spec.Replicas = int32(r)
 	return dc
 }
 
@@ -151,7 +151,7 @@ func (dc *ODeploymentConfig) FindPort(name string) int {
 		for _, val := range dc.Spec.Template.Spec.Containers {
 			for _, port := range val.Ports {
 				if port.Name == name {
-					return port.ContainerPort
+					return int(port.ContainerPort)
 				}
 			}
 		}

--- a/clusters/errors.go
+++ b/clusters/errors.go
@@ -8,7 +8,7 @@ const NoSuchClusterCode = 103
 const ComponentExistsCode = 104
 
 type ClusterError struct {
-	Msg string
+	Msg  string
 	Code int
 }
 

--- a/clusters/services/services.go
+++ b/clusters/services/services.go
@@ -6,31 +6,30 @@ import (
 )
 
 /*
-        {
-            "apiVersion": "v1",
-            "kind": "Service",
-            "metadata": {
-                "labels": {
-                    "name": "spark-master-jpda"
-                },
-                "name": "spark-master-jpda"
-            },
-            "spec": {
-                "ports": [
-                    {
-                        "port": 7077,
-                        "protocol": "TCP",
-                        "targetPort": 7077
-                    }
-                ],
-                "selector": {
-                    "name": "spark-master-jpda"
-                }
-            }
-        },
+   {
+       "apiVersion": "v1",
+       "kind": "Service",
+       "metadata": {
+           "labels": {
+               "name": "spark-master-jpda"
+           },
+           "name": "spark-master-jpda"
+       },
+       "spec": {
+           "ports": [
+               {
+                   "port": 7077,
+                   "protocol": "TCP",
+                   "targetPort": 7077
+               }
+           ],
+           "selector": {
+               "name": "spark-master-jpda"
+           }
+       }
+   },
 
- */
-
+*/
 
 type OService struct {
 	kapi.Service
@@ -86,7 +85,7 @@ type OServicePort struct {
 func ServicePort(port int) *OServicePort {
 	s := OServicePort{}
 	s.ServicePort.Protocol = kapi.ProtocolTCP
-	s.ServicePort.Port = port
+	s.ServicePort.Port = int32(port)
 	return &s
 }
 
@@ -131,4 +130,4 @@ type ServicePort struct {
 	// Default is to auto-allocate a port if the ServiceType of this Service requires one.
 	NodePort int `json:"nodePort"`
 }
- */
+*/


### PR DESCRIPTION
Includes results of "gofmt -w". Modify the code to work against
origin 1.4.1. The major change here is that scaling must be
done against the deploymentconfig and not the replication
controller.